### PR TITLE
Fix weather.js plugin bug with id: lookups.

### DIFF
--- a/plugins/weather.js
+++ b/plugins/weather.js
@@ -17,11 +17,11 @@
     var url = ""
     if (location.match(/^\d+$/)) {
       url = baseURL + "&zip=%S"
-    } else if (location.match(/^\w+/)) {
-      url = baseURL + "&q=%S"
     } else if (location.match(/^id:\d+/)) {
       url = baseURL + "&id=%S"
       location = msg.replace('id:', '').trim()
+    } else if (location.match(/^\w+/)) {
+      url = baseURL + "&q=%S"
     }
 
     if (location === "") {


### PR DESCRIPTION
Order of operations matters - the "id:" matched the location query instead
of the City ID lookup. Reorder the logic so id: is checked first.