### PR TITLE
Fix the storage of the previous weather lookup when used with id: prefixes

### DIFF
--- a/plugins/weather.js
+++ b/plugins/weather.js
@@ -15,10 +15,12 @@
     }
 
     var url = ""
+    var store_location = location
     if (location.match(/^\d+$/)) {
       url = baseURL + "&zip=%S"
     } else if (location.match(/^id:\d+/)) {
       url = baseURL + "&id=%S"
+      store_location = location
       location = location.replace('id:', '').trim()
     } else if (location.match(/^\w+/)) {
       url = baseURL + "&q=%S"
@@ -28,7 +30,7 @@
       cb.call(null, to, from, 'gimme a location!', proto);
     }
 
-    store.users[from] = location
+    store.users[from] = store_location
 
     url = url.replace("%T", store.token)
     url = url.replace("%S", escape(location))


### PR DESCRIPTION
The handling of id: lookups rewrites the location variable prior to its storage,
meaning that the "id:" prefix has been stripped away and when the value is
recalled, the lookup is treated as a zip code instead. This commit resolves
this issue by keeping a separate unaltered variable for the value to be used
with storage.
This functionality will also benefit any other prefix-style lookups in the
future, such as a lat/lon lookup prefix.