### PR TITLE
Include a "body" of the fictitious filename with images

### DIFF
--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -268,7 +268,7 @@ func SendImage(c *gomatrix.Client, roomID string, img *image.RGBA) error {
 		return err
 	}
 
-	_, err = c.SendImage(roomID, "", mediaURL.ContentURI)
+	_, err = c.SendImage(roomID, "embedded_image.png", mediaURL.ContentURI)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Some clients (like Cinny.in) expect there to be a content.body element present
in m.image messages, and will complain "Malformed event" if this value is empty.

See https://matrix.to/#/!LuCIijTlkphnqdzPoB:pintobyte.com/$wPlVlBBCEOhf1ZQR6wBSDGDRtJtCUZtXp6qopkUIz30?via=cobryce.com&via=pintobyte.com&via=matrix.org

See https://github.com/cinnyapp/cinny/blob/3c1cc59d599bb5dcb2adf327d059601ada5bb5e4/src/app/molecules/message/Message.jsx#L613
